### PR TITLE
🐛 修复 powerlevel10k 在 Git worktree 中无法显示状态的问题

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -59,6 +59,9 @@ export ZSH_CUSTOM="$ZDOTDIR/oh-my-custom"
 ZSH_THEME="powerlevel10k/powerlevel10k"
 # To customize prompt, run `p10k configure` or edit $DOTFILES/zsh/p10k.zsh.
 [[ ! -f $ZDOTDIR/p10k.zsh ]] || source $ZDOTDIR/p10k.zsh
+# p10k 使用的 gitstatus 使用的 gitlib2 不支持 git 中 worktree 等 extentions 特性
+# see https://github.com/xdanger/dotfiles/issues/2
+POWERLEVEL9K_DISABLE_GITSTATUS=true
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
## 概要

- 🐛 通过禁用 gitstatus 修复 powerlevel10k 在 Git worktree 中无法显示状态的问题
- 📝 添加相关注释说明问题原因和解决方案

## 问题描述

当前 powerlevel10k 在启用了 `extensions.worktreeConfig` 的 Git worktree 目录中无法显示 Git 状态信息。

## 解决方案

设置 `POWERLEVEL9K_DISABLE_GITSTATUS=true` 禁用 gitstatus，强制 p10k 使用原生 git 命令获取仓库状态。

## 技术背景

- powerlevel10k 默认使用 gitstatus 模块获取 Git 仓库状态
- gitstatus 底层依赖 libgit2 库
- libgit2 目前不支持带有 `extensions.worktreeConfig` 的 worktree
- 通过禁用 gitstatus，可以回退到使用原生 git 命令

## 测试计划

- [x] 在普通 Git 仓库中测试 Git 状态显示正常
- [x] 在 Git worktree 目录中测试 Git 状态显示正常
- [x] 确认性能影响在可接受范围内

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)